### PR TITLE
Remove wrong info and convert CSS unit

### DIFF
--- a/examples/users-list/README.md
+++ b/examples/users-list/README.md
@@ -1,7 +1,5 @@
 # UI Design Daily - User List (Day 1542)
 
-This is a solution to the Four card feature section challenge on Frontend Mentor.
-
 - [UI Design Daily - User List (Day 1542)](#ui-design-daily---user-list-day-1542)
   - [Overview](#overview)
     - [The design](#the-design)

--- a/examples/users-list/style.css
+++ b/examples/users-list/style.css
@@ -181,7 +181,7 @@ img {
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 48em) {
   .userList__body {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
Remove wrong info in README.md and convert `px` to `em` unit in CSS media queries.